### PR TITLE
Restrict patient payments to read-only

### DIFF
--- a/database/seeders/MenuSeeder.php
+++ b/database/seeders/MenuSeeder.php
@@ -28,6 +28,7 @@ class MenuSeeder extends Seeder
             // Paciente
             ['nombre' => 'Mis Citas',         'ruta' => '/citas',             'rol' => 'P', 'orden' => 1],
             ['nombre' => 'Mi Historial',      'ruta' => '/historial-clinico', 'rol' => 'P', 'orden' => 2],
+            ['nombre' => 'Mis Pagos',         'ruta' => '/pagos',            'rol' => 'P', 'orden' => 3],
         ]);
     }
 }

--- a/resources/js/Pages/Pagos/Index.vue
+++ b/resources/js/Pages/Pagos/Index.vue
@@ -1,11 +1,13 @@
 <script setup>
-import { Link } from '@inertiajs/vue3'
+import { Link, usePage } from '@inertiajs/vue3'
 import BackToDashboard from '@/Components/BackToDashboard.vue'
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
 
 const props = defineProps({
   pagos: Object
 })
+
+const user = usePage().props.auth.user
 </script>
 
 <template>
@@ -14,7 +16,11 @@ const props = defineProps({
     <div class="max-w-5xl mx-auto mt-10">
       <div class="flex justify-between items-center mb-6">
         <h1 class="text-2xl font-bold">Pagos</h1>
-        <Link :href="route('pagos.create')" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded">
+        <Link
+          v-if="user.tipo_usuario === 'A'"
+          :href="route('pagos.create')"
+          class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+        >
           Nuevo Pago
         </Link>
       </div>
@@ -63,8 +69,18 @@ const props = defineProps({
               >
                 Ver QR
               </Link>
-              <Link :href="route('pagos.edit', p.id)" class="btn btn-edit">Editar</Link>
-              <form :action="route('pagos.destroy', p.id)" method="post" @submit.prevent="$inertia.delete(route('pagos.destroy', p.id))" class="inline">
+              <Link
+                v-if="user.tipo_usuario === 'A'"
+                :href="route('pagos.edit', p.id)"
+                class="btn btn-edit"
+              >Editar</Link>
+              <form
+                v-if="user.tipo_usuario === 'A'"
+                :action="route('pagos.destroy', p.id)"
+                method="post"
+                @submit.prevent="$inertia.delete(route('pagos.destroy', p.id))"
+                class="inline"
+              >
                 <button type="submit" class="btn btn-danger">Eliminar</button>
               </form>
             </td>

--- a/resources/js/Pages/Pagos/Show.vue
+++ b/resources/js/Pages/Pagos/Show.vue
@@ -141,7 +141,7 @@
       </div>
 
       <!-- Botón de acción -->
-      <div class="mt-8 flex justify-end">
+      <div class="mt-8 flex justify-end" v-if="user.tipo_usuario === 'A'">
         <button
           @click="marcarComoPagado"
           class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
@@ -157,7 +157,7 @@
 </template>
 
 <script setup>
-import { useForm, router } from '@inertiajs/vue3';
+import { useForm, router, usePage } from '@inertiajs/vue3';
 import { ref } from 'vue';
 import { toast } from 'vue3-toastify';
 import 'vue3-toastify/dist/index.css';
@@ -168,6 +168,8 @@ const props = defineProps({
   qr: String,
   qrData: Object
 });
+
+const user = usePage().props.auth.user;
 
 const copiarAlPortapapeles = async (texto) => {
   try {

--- a/routes/web.php
+++ b/routes/web.php
@@ -85,9 +85,8 @@ Route::middleware(['auth', 'checkrole:P'])->group(function () {
         return Inertia::render('Pacientes/Dashboard');
     })->name('paciente.dashboard');
 
-    // Pagos: solo el paciente autenticado puede ver/gestionar sus pagos
-    Route::resource('pagos', PagoController::class)->only(['index', 'show', 'create', 'store']);
-    // Si deseas permitir editar/eliminar pagos propios, agrega 'edit', 'update', 'destroy' al array
+    // Pagos: los pacientes solo pueden visualizar los suyos
+    Route::resource('pagos', PagoController::class)->only(['index', 'show']);
 });
 Route::middleware(['auth', 'checkrole:M'])->group(function () {
     Route::get('/medico', function () {


### PR DESCRIPTION
## Summary
- allow admins to manage payments while patients only list their own
- add patient menu entry for payments
- hide payment actions from non-admins in the UI

## Testing
- `php artisan test` *(fails: missing vendor autoload)*

------
https://chatgpt.com/codex/tasks/task_e_687a66e2de6c8324a89487a6ae75106b